### PR TITLE
Feature/11 banner view support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Released on 2018-11-30.
 
 #### Added
 
+- Added `BannerViewClosure`, for adding one or more subviews to the `bannerView` instance of `PageViewController`.
 - Added `EventsProtocol`.
   - Added by [Bart Hopster](https://github.com/barthopster).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,8 +12,8 @@ Released on 2018-11-30.
 
 #### Added
 
-- Added `BannerViewClosure`, for adding one or more subviews to the `bannerView` instance of `PageViewController`.
 - Added `ForwardedEventsProtocol`.
+- Added support for a footer view below `Segnify`.
   - Added by [Bart Hopster](https://github.com/barthopster).
 
 ## [1.1.0](https://github.com/nedap/Segnify/releases/tag/1.1.0)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,13 +8,18 @@ All notable changes to this project will be documented in this file.
 
 ---
 ## [1.1.1](https://github.com/nedap/Segnify/releases/tag/1.1.1)
-Released on 2018-11-30.
+Released on 2018-12-XX.
 
 #### Added
 
-- Added `ForwardedEventsProtocol`.
-- Added support for a footer view below `Segnify`.
+- Added `ForwardedEventsProtocol` ([#8](https://github.com/nedap/Segnify/issues/8))
+- Added support for a [banner view](https://github.com/nedap/Segnify/issues/11).
   - Added by [Bart Hopster](https://github.com/barthopster).
+
+#### Updated
+
+- Extended the ['UIPageViewController' protocol implementations](https://github.com/nedap/Segnify/issues/8).
+	- Added by [Bart Hopster](https://github.com/barthopster).
 
 ## [1.1.0](https://github.com/nedap/Segnify/releases/tag/1.1.0)
 Released on 2018-11-28.
@@ -27,7 +32,7 @@ Released on 2018-11-28.
 - Added `SegnifyEventsProtocol`. The delegate which implements this protocol will be notified about `Segment` selection changes of `Segnify`.
 - Added `DefaultDelegates`, which offers a default implementation of almost all protocols.
 - Added the example app `Segnified` inside the Xcode project, next to the `Segnify` framework, for improved development and testing processes.
-- Added support for infinite scrolling.
+- Added support for [infinite scrolling](https://github.com/nedap/Segnify/issues/3).
   - Added by [Bart Hopster](https://github.com/barthopster).
 
 #### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ Released on 2018-11-30.
 #### Added
 
 - Added `BannerViewClosure`, for adding one or more subviews to the `bannerView` instance of `PageViewController`.
-- Added `EventsProtocol`.
+- Added `ForwardedEventsProtocol`.
   - Added by [Bart Hopster](https://github.com/barthopster).
 
 ## [1.1.0](https://github.com/nedap/Segnify/releases/tag/1.1.0)

--- a/README.md
+++ b/README.md
@@ -189,9 +189,9 @@ Take a look at the [Segnified](https://github.com/nedap/Segnify/blob/master/Segn
 
 For customization purposes, which you'd likely need, implement one or more of the following protocols.
 
-### EventsProtocol
+### ForwardedEventsProtocol
 
-Implement `EventsProtocol` for the ability to be informed about several events, caused by either the `Segnify` instance or the `UIPageViewController` instance:
+Implement `ForwardedEventsProtocol ` for the ability to be informed about several events, caused by either the `Segnify` instance or the `UIPageViewController` instance:
 
 - Getting the view controller before the currently displayed one
 - Getting the view controller after the currently displayed one

--- a/README.md
+++ b/README.md
@@ -243,28 +243,32 @@ public struct DefaultPageViewControllerDelegate: PageViewControllerProtocol {
 
 Implement `SegnicatorProtocol` for visually customizing the `Segnicator` instance. In the example below, the default implementation in [DefaultSegnicatorDelegate](Segnify/Protocols/Defaults/DefaultSegnicatorDelegate.swift) is being shown.
 
-A white, horizontal line is created and added as a subview. Auto Layout constraints have been applied using the `SegnifyLayoutConstraint` extension. By using the `SegnicatorSubviewsClosure` typealias, subviews and Auto Layout constraints can easily be added, as it takes a reference to a `Segnicator` instance as a parameter.
+A white, horizontal line is created and added as a subview. Auto Layout constraints have been applied using the `SegnifyLayoutConstraint` extension.
 
 ```swift
 public struct DefaultSegnicatorDelegate: SegnicatorProtocol {
 
     // MARK: - Delegate
     
-    public var segnicatorSubviewsClosure: SegnicatorSubviewsClosure {
-        return { segnicator in
-            // Create a white, horizontal indicator view.
-            let whiteIndicatorView = UIView()
-            whiteIndicatorView.backgroundColor = .white
-            
-            // Add it to the segnicator and give it the correct layout.
-            segnicator.addSubview(whiteIndicatorView)
-            NSLayoutConstraint.activate([
-                whiteIndicatorView.leadingAnchor.constraint(equalTo: segnicator.leadingAnchor),
-                whiteIndicatorView.trailingAnchor.constraint(equalTo: segnicator.trailingAnchor),
-                whiteIndicatorView.bottomAnchor.constraint(equalTo: segnicator.bottomAnchor),
-                whiteIndicatorView.heightAnchor.constraint(equalToConstant: 2.0)
-                ], for: whiteIndicatorView)
-        }
+    public var segnicatorView: UIView {
+        // Create a white, half-transparent background view.
+        let backgroundView = UIView()
+        backgroundView.backgroundColor = .clear
+        
+        // Create a white, horizontal indicator view.
+        let whiteIndicatorView = UIView()
+        whiteIndicatorView.backgroundColor = .white
+        
+        // Add it to the segnicator and give it the correct layout.
+        backgroundView.addSubview(whiteIndicatorView)
+        NSLayoutConstraint.activate([
+            whiteIndicatorView.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor),
+            whiteIndicatorView.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor),
+            whiteIndicatorView.trailingAnchor.constraint(equalTo: backgroundView.trailingAnchor),
+            whiteIndicatorView.heightAnchor.constraint(equalToConstant: 2.0)
+            ], for: whiteIndicatorView)
+        
+        return backgroundView
     }
 }
 ```

--- a/Segnified/Delegates/PageViewControllerDelegate.swift
+++ b/Segnified/Delegates/PageViewControllerDelegate.swift
@@ -15,29 +15,5 @@ struct PageViewControllerDelegate: PageViewControllerProtocol {
     
     var backgroundColor: UIColor = .white
     
-    var footerView: UIView {
-        // Create a footer view ...
-        let footerView = UIView()
-        footerView.backgroundColor = .lightGray
-        
-        // ... with a text label.
-        let textLabel = UILabel()
-        textLabel.text = "Gorgeous banner view!"
-        textLabel.textAlignment = .center
-        
-        // Add them as subviews and add Auto Layout constraints.
-        footerView.addSubview(textLabel)
-        NSLayoutConstraint.activate([
-            textLabel.topAnchor.constraint(equalTo: footerView.topAnchor),
-            textLabel.leadingAnchor.constraint(equalTo: footerView.leadingAnchor),
-            textLabel.bottomAnchor.constraint(equalTo: footerView.bottomAnchor),
-            textLabel.trailingAnchor.constraint(equalTo: footerView.trailingAnchor),
-            ], for: textLabel)
-        
-        return footerView
-    }
-    
-    var footerViewHeight: CGFloat = 44.0
-    
-    var segnifyHeight: CGFloat = 100.0
+    var segnifyHeight: CGFloat = 144.0
 }

--- a/Segnified/Delegates/PageViewControllerDelegate.swift
+++ b/Segnified/Delegates/PageViewControllerDelegate.swift
@@ -15,36 +15,29 @@ struct PageViewControllerDelegate: PageViewControllerProtocol {
     
     var backgroundColor: UIColor = .white
     
-    var bannerViewClosure: BannerViewClosure {
-        return { superview in
-            // Create a banner view ...
-            let bannerView = UIView()
-            bannerView.backgroundColor = .lightGray
-            
-            // ... with a text label.
-            let textLabel = UILabel()
-            textLabel.text = "Gorgeous banner view!"
-            textLabel.textAlignment = .center
-            
-            // Add them as subviews and add Auto Layout constraints.
-            bannerView.addSubview(textLabel)
-            NSLayoutConstraint.activate([
-                textLabel.topAnchor.constraint(equalTo: bannerView.topAnchor),
-                textLabel.leadingAnchor.constraint(equalTo: bannerView.leadingAnchor),
-                textLabel.bottomAnchor.constraint(equalTo: bannerView.bottomAnchor),
-                textLabel.trailingAnchor.constraint(equalTo: bannerView.trailingAnchor),
-                ], for: textLabel)
-            
-            superview.addSubview(bannerView)
-            NSLayoutConstraint.activate([
-                bannerView.topAnchor.constraint(equalTo: superview.topAnchor),
-                bannerView.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-                bannerView.bottomAnchor.constraint(equalTo: superview.bottomAnchor),
-                bannerView.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
-                bannerView.heightAnchor.constraint(equalToConstant: 35.0)
-                ], for: bannerView)
-        }
+    var footerView: UIView {
+        // Create a footer view ...
+        let footerView = UIView()
+        footerView.backgroundColor = .lightGray
+        
+        // ... with a text label.
+        let textLabel = UILabel()
+        textLabel.text = "Gorgeous banner view!"
+        textLabel.textAlignment = .center
+        
+        // Add them as subviews and add Auto Layout constraints.
+        footerView.addSubview(textLabel)
+        NSLayoutConstraint.activate([
+            textLabel.topAnchor.constraint(equalTo: footerView.topAnchor),
+            textLabel.leadingAnchor.constraint(equalTo: footerView.leadingAnchor),
+            textLabel.bottomAnchor.constraint(equalTo: footerView.bottomAnchor),
+            textLabel.trailingAnchor.constraint(equalTo: footerView.trailingAnchor),
+            ], for: textLabel)
+        
+        return footerView
     }
+    
+    var footerViewHeight: CGFloat = 44.0
     
     var segnifyHeight: CGFloat = 100.0
 }

--- a/Segnified/Delegates/PageViewControllerDelegate.swift
+++ b/Segnified/Delegates/PageViewControllerDelegate.swift
@@ -15,5 +15,5 @@ struct PageViewControllerDelegate: PageViewControllerProtocol {
     
     var backgroundColor: UIColor = .white
     
-    var segnifyHeight: CGFloat = 125.0
+    var segnifyHeight: CGFloat = 75.0
 }

--- a/Segnified/Delegates/PageViewControllerDelegate.swift
+++ b/Segnified/Delegates/PageViewControllerDelegate.swift
@@ -15,5 +15,36 @@ struct PageViewControllerDelegate: PageViewControllerProtocol {
     
     var backgroundColor: UIColor = .white
     
+    var bannerViewClosure: BannerViewClosure {
+        return { superview in
+            // Create a banner view ...
+            let bannerView = UIView()
+            bannerView.backgroundColor = .lightGray
+            
+            // ... with a text label.
+            let textLabel = UILabel()
+            textLabel.text = "Gorgeous banner view!"
+            textLabel.textAlignment = .center
+            
+            // Add them as subviews and add Auto Layout constraints.
+            bannerView.addSubview(textLabel)
+            NSLayoutConstraint.activate([
+                textLabel.topAnchor.constraint(equalTo: bannerView.topAnchor),
+                textLabel.leadingAnchor.constraint(equalTo: bannerView.leadingAnchor),
+                textLabel.bottomAnchor.constraint(equalTo: bannerView.bottomAnchor),
+                textLabel.trailingAnchor.constraint(equalTo: bannerView.trailingAnchor),
+                ], for: textLabel)
+            
+            superview.addSubview(bannerView)
+            NSLayoutConstraint.activate([
+                bannerView.topAnchor.constraint(equalTo: superview.topAnchor),
+                bannerView.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
+                bannerView.bottomAnchor.constraint(equalTo: superview.bottomAnchor),
+                bannerView.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
+                bannerView.heightAnchor.constraint(equalToConstant: 35.0)
+                ], for: bannerView)
+        }
+    }
+    
     var segnifyHeight: CGFloat = 100.0
 }

--- a/Segnified/Delegates/PageViewControllerDelegate.swift
+++ b/Segnified/Delegates/PageViewControllerDelegate.swift
@@ -15,5 +15,5 @@ struct PageViewControllerDelegate: PageViewControllerProtocol {
     
     var backgroundColor: UIColor = .white
     
-    var segnifyHeight: CGFloat = 144.0
+    var segnifyHeight: CGFloat = 125.0
 }

--- a/Segnified/Delegates/SegnicatorDelegate.swift
+++ b/Segnified/Delegates/SegnicatorDelegate.swift
@@ -13,33 +13,24 @@ struct SegnicatorDelegate: SegnicatorProtocol {
     
     // MARK: - Delegate
     
-    var segnicatorSubviewsClosure: SegnicatorSubviewsClosure {
-        return { segnicator in
-            // Create a white, half-transparent background view.
-            let backgroundView = UIView()
-            backgroundView.backgroundColor = .init(white: 1.0, alpha: 0.4)
-            
-            // Add it to the segnicator and give it the correct layout.
-            segnicator.addSubview(backgroundView)
-            NSLayoutConstraint.activate([
-                backgroundView.topAnchor.constraint(equalTo: segnicator.topAnchor),
-                backgroundView.leadingAnchor.constraint(equalTo: segnicator.leadingAnchor),
-                backgroundView.bottomAnchor.constraint(equalTo: segnicator.bottomAnchor),
-                backgroundView.trailingAnchor.constraint(equalTo: segnicator.trailingAnchor)
-                ], for: backgroundView)
-            
-            // Create a white, horizontal indicator view.
-            let whiteIndicatorView = UIView()
-            whiteIndicatorView.backgroundColor = .white
-            
-            // Add it to the segnicator and give it the correct layout.
-            segnicator.addSubview(whiteIndicatorView)
-            NSLayoutConstraint.activate([
-                whiteIndicatorView.leadingAnchor.constraint(equalTo: segnicator.leadingAnchor),
-                whiteIndicatorView.bottomAnchor.constraint(equalTo: segnicator.bottomAnchor),
-                whiteIndicatorView.trailingAnchor.constraint(equalTo: segnicator.trailingAnchor),
-                whiteIndicatorView.heightAnchor.constraint(equalToConstant: 2.0)
-                ], for: whiteIndicatorView)
-        }
+    var segnicatorView: UIView {
+        // Create a white, half-transparent background view.
+        let backgroundView = UIView()
+        backgroundView.backgroundColor = .init(white: 1.0, alpha: 0.4)
+        
+        // Create a white, horizontal indicator view.
+        let whiteIndicatorView = UIView()
+        whiteIndicatorView.backgroundColor = .white
+        
+        // Add it to the segnicator and give it the correct layout.
+        backgroundView.addSubview(whiteIndicatorView)
+        NSLayoutConstraint.activate([
+            whiteIndicatorView.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor),
+            whiteIndicatorView.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor),
+            whiteIndicatorView.trailingAnchor.constraint(equalTo: backgroundView.trailingAnchor),
+            whiteIndicatorView.heightAnchor.constraint(equalToConstant: 2.0)
+            ], for: whiteIndicatorView)
+        
+        return backgroundView
     }
 }

--- a/Segnified/Delegates/SegnifyDelegate.swift
+++ b/Segnified/Delegates/SegnifyDelegate.swift
@@ -15,6 +15,30 @@ struct SegnifyDelegate: SegnifyProtocol {
     
     var backgroundColor: UIColor = .white
     
+    var footerView: UIView {
+        // Create a footer view ...
+        let footerView = UIView()
+        footerView.backgroundColor = .lightGray
+        
+        // ... with a text label.
+        let textLabel = UILabel()
+        textLabel.text = "Gorgeous banner view!"
+        textLabel.textAlignment = .center
+        
+        // Add them as subviews and add Auto Layout constraints.
+        footerView.addSubview(textLabel)
+        NSLayoutConstraint.activate([
+            textLabel.topAnchor.constraint(equalTo: footerView.topAnchor),
+            textLabel.leadingAnchor.constraint(equalTo: footerView.leadingAnchor),
+            textLabel.bottomAnchor.constraint(equalTo: footerView.bottomAnchor),
+            textLabel.trailingAnchor.constraint(equalTo: footerView.trailingAnchor),
+            ], for: textLabel)
+        
+        return footerView
+    }
+    
+    var footerViewHeight: CGFloat = 44.0
+    
     var isEquallyFillingHorizontalSpace: Bool = false
     
     var segmentWidth: CGFloat = 175.0

--- a/Segnified/Delegates/SegnifyDelegate.swift
+++ b/Segnified/Delegates/SegnifyDelegate.swift
@@ -32,12 +32,11 @@ struct SegnifyDelegate: SegnifyProtocol {
             textLabel.leadingAnchor.constraint(equalTo: footerView.leadingAnchor),
             textLabel.bottomAnchor.constraint(equalTo: footerView.bottomAnchor),
             textLabel.trailingAnchor.constraint(equalTo: footerView.trailingAnchor),
+            textLabel.heightAnchor.constraint(equalToConstant: 35.0)
             ], for: textLabel)
         
         return footerView
     }
-    
-    var footerViewHeight: CGFloat = 44.0
     
     var isEquallyFillingHorizontalSpace: Bool = false
     

--- a/Segnify.xcodeproj/project.pbxproj
+++ b/Segnify.xcodeproj/project.pbxproj
@@ -27,7 +27,7 @@
 		20430F85214A92F100C47CC6 /* ImageSegmentProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20430F84214A92F100C47CC6 /* ImageSegmentProtocol.swift */; };
 		208E49B72188AFC10089F6B9 /* SegnifyEventsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 208E49B62188AFC10089F6B9 /* SegnifyEventsProtocol.swift */; };
 		209DD35121ADFBF800862F17 /* Segnify.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = 201FD1852147A48600CF374B /* Segnify.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		209DD35F21B138F800862F17 /* EventsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209DD35E21B138F800862F17 /* EventsProtocol.swift */; };
+		209DD35F21B138F800862F17 /* ForwardedEventsProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209DD35E21B138F800862F17 /* ForwardedEventsProtocol.swift */; };
 		209E3335218719170014115F /* PageViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209E3334218719170014115F /* PageViewController.swift */; };
 		209E333F21874DA80014115F /* PageViewControllerProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209E333E21874DA80014115F /* PageViewControllerProtocol.swift */; };
 		209F40B6214801D500212277 /* Segnicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 209F40B5214801D500212277 /* Segnicator.swift */; };
@@ -82,7 +82,7 @@
 		20430F81214A5A6200C47CC6 /* ImageSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSegment.swift; sourceTree = "<group>"; };
 		20430F84214A92F100C47CC6 /* ImageSegmentProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSegmentProtocol.swift; sourceTree = "<group>"; };
 		208E49B62188AFC10089F6B9 /* SegnifyEventsProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SegnifyEventsProtocol.swift; sourceTree = "<group>"; };
-		209DD35E21B138F800862F17 /* EventsProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EventsProtocol.swift; sourceTree = "<group>"; };
+		209DD35E21B138F800862F17 /* ForwardedEventsProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ForwardedEventsProtocol.swift; sourceTree = "<group>"; };
 		209E3334218719170014115F /* PageViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewController.swift; sourceTree = "<group>"; };
 		209E333E21874DA80014115F /* PageViewControllerProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PageViewControllerProtocol.swift; sourceTree = "<group>"; };
 		209F40B5214801D500212277 /* Segnicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Segnicator.swift; sourceTree = "<group>"; };
@@ -198,7 +198,7 @@
 			isa = PBXGroup;
 			children = (
 				209E3340218767640014115F /* Defaults */,
-				209DD35E21B138F800862F17 /* EventsProtocol.swift */,
+				209DD35E21B138F800862F17 /* ForwardedEventsProtocol.swift */,
 				20430F84214A92F100C47CC6 /* ImageSegmentProtocol.swift */,
 				209E333E21874DA80014115F /* PageViewControllerProtocol.swift */,
 				20430F7D21490CDA00C47CC6 /* SegmentProtocol.swift */,
@@ -410,7 +410,7 @@
 				20430F82214A5A6200C47CC6 /* ImageSegment.swift in Sources */,
 				201FD1942147A7DC00CF374B /* SegnifyProtocol.swift in Sources */,
 				209E333F21874DA80014115F /* PageViewControllerProtocol.swift in Sources */,
-				209DD35F21B138F800862F17 /* EventsProtocol.swift in Sources */,
+				209DD35F21B138F800862F17 /* ForwardedEventsProtocol.swift in Sources */,
 				209F40BB2148185500212277 /* SegnicatorProtocol.swift in Sources */,
 				201FD1962147A91800CF374B /* Segment.swift in Sources */,
 				201F520521ADF02800BF930B /* DefaultSegnifyDataSourceDelegate.swift in Sources */,

--- a/Segnify/Protocols/Defaults/DefaultSegnicatorDelegate.swift
+++ b/Segnify/Protocols/Defaults/DefaultSegnicatorDelegate.swift
@@ -11,20 +11,24 @@ public struct DefaultSegnicatorDelegate: SegnicatorProtocol {
 
     // MARK: - Delegate
     
-    public var segnicatorSubviewsClosure: SegnicatorSubviewsClosure {
-        return { segnicator in
-            // Create a white, horizontal indicator view.
-            let whiteIndicatorView = UIView()
-            whiteIndicatorView.backgroundColor = .white
-            
-            // Add it to the segnicator and give it the correct layout.
-            segnicator.addSubview(whiteIndicatorView)
-            NSLayoutConstraint.activate([
-                whiteIndicatorView.leadingAnchor.constraint(equalTo: segnicator.leadingAnchor),
-                whiteIndicatorView.trailingAnchor.constraint(equalTo: segnicator.trailingAnchor),
-                whiteIndicatorView.bottomAnchor.constraint(equalTo: segnicator.bottomAnchor),
-                whiteIndicatorView.heightAnchor.constraint(equalToConstant: 2.0)
-                ], for: whiteIndicatorView)
-        }
+    public var segnicatorView: UIView {
+        // Create a white, half-transparent background view.
+        let backgroundView = UIView()
+        backgroundView.backgroundColor = .clear
+        
+        // Create a white, horizontal indicator view.
+        let whiteIndicatorView = UIView()
+        whiteIndicatorView.backgroundColor = .white
+        
+        // Add it to the segnicator and give it the correct layout.
+        backgroundView.addSubview(whiteIndicatorView)
+        NSLayoutConstraint.activate([
+            whiteIndicatorView.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor),
+            whiteIndicatorView.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor),
+            whiteIndicatorView.trailingAnchor.constraint(equalTo: backgroundView.trailingAnchor),
+            whiteIndicatorView.heightAnchor.constraint(equalToConstant: 2.0)
+            ], for: whiteIndicatorView)
+        
+        return backgroundView
     }
 }

--- a/Segnify/Protocols/EventsProtocol.swift
+++ b/Segnify/Protocols/EventsProtocol.swift
@@ -54,21 +54,26 @@ public protocol EventsProtocol {
 
 extension EventsProtocol {
     
+    /// Provide a default implementation.
     public func pageViewController(_ pageViewController: UIPageViewController,
                                    requested viewController: UIViewController?,
                                    before previousViewController: UIViewController) {}
     
+    /// Provide a default implementation.
     public func pageViewController(_ pageViewController: UIPageViewController,
                                    requested viewController: UIViewController?,
                                    after previousViewController: UIViewController) {}
     
+    /// Provide a default implementation.
     public func pageViewController(_ pageViewController: UIPageViewController,
                                    willTransitionTo pendingViewControllers: [UIViewController]) {}
     
+    /// Provide a default implementation.
     public func pageViewController(_ pageViewController: UIPageViewController,
                                    didFinishAnimating finished: Bool,
                                    previousViewControllers: [UIViewController],
                                    transitionCompleted completed: Bool) {}
     
+    /// Provide a default implementation.
     public func segnify(_ segnify: Segnify, receivedTouchInside segment: Segment) {}
 }

--- a/Segnify/Protocols/ForwardedEventsProtocol.swift
+++ b/Segnify/Protocols/ForwardedEventsProtocol.swift
@@ -1,5 +1,5 @@
 //
-//  EventsProtocol.swift
+//  ForwardedEventsProtocol.swift
 //  Segnify
 //
 //  Created by Bart Hopster on 30/11/2018.
@@ -18,7 +18,7 @@ import UIKit
 ///
 /// The protocol partly relies on the `UIPageViewControllerDataSource` and `UIPageViewControllerDelegate` protocols.
 /// In this way, the implementations in `PageViewController` aren't at risk.
-public protocol EventsProtocol {
+public protocol ForwardedEventsProtocol {
     
     /// Based on the corresponding `UIPageViewControllerDataSource` protocol, this method returns both the view controller
     /// before the currently viewed view controller, where the user navigated away from, and the latter view controller.
@@ -52,7 +52,7 @@ public protocol EventsProtocol {
 
 // MARK: - Defaults
 
-extension EventsProtocol {
+extension ForwardedEventsProtocol {
     
     /// Provide a default implementation.
     public func pageViewController(_ pageViewController: UIPageViewController,

--- a/Segnify/Protocols/ImageSegmentProtocol.swift
+++ b/Segnify/Protocols/ImageSegmentProtocol.swift
@@ -25,7 +25,7 @@ public protocol ImageSegmentProtocol: SegmentProtocol {
 
 extension ImageSegmentProtocol {
     
-    /// Provide a default value.
+    /// Provide a default implementation.
     public func isAdjustingImage(for state: UIControl.State) -> Bool {
         return false
     }

--- a/Segnify/Protocols/ImageSegmentProtocol.swift
+++ b/Segnify/Protocols/ImageSegmentProtocol.swift
@@ -10,12 +10,12 @@ import UIKit
 
 /// Customize any `ImageSegment` appearance by implementing this protocol.
 public protocol ImageSegmentProtocol: SegmentProtocol {
-
-    /// Defines if the image of the `ImageSegment` instance should be adjusted for the different states.
-    func isAdjustingImage(for state: UIControl.State) -> Bool
     
     /// The edge insets to be applied to the image view of the `ImageSegment` instance.
     var imageViewEdgeInsets: UIEdgeInsets { get }
+    
+    /// Defines if the image of the `ImageSegment` instance should be adjusted for the different states.
+    func isAdjustingImage(for state: UIControl.State) -> Bool
     
     /// Defines the tint color of the `ImageSegment` instance.
     var tintColor: UIColor? { get }

--- a/Segnify/Protocols/PageViewControllerProtocol.swift
+++ b/Segnify/Protocols/PageViewControllerProtocol.swift
@@ -22,9 +22,6 @@ public protocol PageViewControllerProtocol {
     /// Add one or more subviews to the `bannerView` instance of `PageViewController`.
     var bannerViewClosure: BannerViewClosure { get }
     
-    /// Specifies the height of the `bannerView` instance.
-    var bannerViewHeight: CGFloat { get }
-    
     /// Specifies the height of the `Segnify` component in `PageViewController`.
     /// The height will be realised using Auto Layout constraints.
     var segnifyHeight: CGFloat { get }
@@ -37,10 +34,5 @@ extension PageViewControllerProtocol {
     /// Provide a default value.
     public var bannerViewClosure: BannerViewClosure {
         return { _ in }
-    }
-    
-    /// Provide a default value.
-    public var bannerViewHeight: CGFloat {
-        return 0.0
     }
 }

--- a/Segnify/Protocols/PageViewControllerProtocol.swift
+++ b/Segnify/Protocols/PageViewControllerProtocol.swift
@@ -8,19 +8,19 @@
 
 import UIKit
 
-/// A closure with a reference to a `bannerView`, a `UIView` instance, for adding one or more subviews
-/// to that `bannerView` instance of `PageViewController` and adding Auto Layout constraints to them.
-public typealias BannerViewClosure = (UIView) -> ()
-
 /// Configure a `PageViewController` instance by implementing this protocol.
 /// The background color of the view and the height of its `Segnify` instance can be configured.
+/// A footer view can be configured as well.
 public protocol PageViewControllerProtocol {
     
     /// Specifies the background color of the main view.
     var backgroundColor: UIColor { get }
     
-    /// Add one or more subviews to the `bannerView` instance of `PageViewController`.
-    var bannerViewClosure: BannerViewClosure { get }
+    /// Specifies an optional footer view below the `Segnify` instance.
+    var footerView: UIView { get }
+    
+    /// Specifies the height of the footer view below the `Segnify` instance.
+    var footerViewHeight: CGFloat { get }
     
     /// Specifies the height of the `Segnify` component in `PageViewController`.
     /// The height will be realised using Auto Layout constraints.
@@ -32,7 +32,11 @@ public protocol PageViewControllerProtocol {
 extension PageViewControllerProtocol {
     
     /// Provide a default value.
-    public var bannerViewClosure: BannerViewClosure {
-        return { _ in }
+    public var footerView: UIView {
+        return UIView()
+    }
+    
+    public var footerViewHeight: CGFloat {
+        return 0.0
     }
 }

--- a/Segnify/Protocols/PageViewControllerProtocol.swift
+++ b/Segnify/Protocols/PageViewControllerProtocol.swift
@@ -38,6 +38,8 @@ extension PageViewControllerProtocol {
             let blankView = UIView()
             blankView.backgroundColor = .clear
             
+            // Add as subview and add Auto Layout constraints.
+            superview.addSubview(blankView)
             NSLayoutConstraint.activate([
                 blankView.topAnchor.constraint(equalTo: superview.topAnchor),
                 blankView.leadingAnchor.constraint(equalTo: superview.leadingAnchor),

--- a/Segnify/Protocols/PageViewControllerProtocol.swift
+++ b/Segnify/Protocols/PageViewControllerProtocol.swift
@@ -10,33 +10,12 @@ import UIKit
 
 /// Configure a `PageViewController` instance by implementing this protocol.
 /// The background color of the view and the height of its `Segnify` instance can be configured.
-/// A footer view can be configured as well.
 public protocol PageViewControllerProtocol {
     
     /// Specifies the background color of the main view.
     var backgroundColor: UIColor { get }
     
-    /// Specifies an optional footer view below the `Segnify` instance.
-    var footerView: UIView { get }
-    
-    /// Specifies the height of the footer view below the `Segnify` instance.
-    var footerViewHeight: CGFloat { get }
-    
     /// Specifies the height of the `Segnify` component in `PageViewController`.
     /// The height will be realised using Auto Layout constraints.
     var segnifyHeight: CGFloat { get }
-}
-
-// MARK: - Defaults
-
-extension PageViewControllerProtocol {
-    
-    /// Provide a default value.
-    public var footerView: UIView {
-        return UIView()
-    }
-    
-    public var footerViewHeight: CGFloat {
-        return 0.0
-    }
 }

--- a/Segnify/Protocols/PageViewControllerProtocol.swift
+++ b/Segnify/Protocols/PageViewControllerProtocol.swift
@@ -8,9 +8,9 @@
 
 import UIKit
 
-/// A closure for adding one or more subviews to the `bannerView` instance of `PageViewController`
-/// and adding Auto Layout constraints to them.
-public typealias BannerViewClosure = () -> ()
+/// A closure with a reference to a `bannerView`, a `UIView` instance, for adding one or more subviews
+/// to that `bannerView` instance of `PageViewController` and adding Auto Layout constraints to them.
+public typealias BannerViewClosure = (UIView) -> ()
 
 /// Configure a `PageViewController` instance by implementing this protocol.
 /// The background color of the view and the height of its `Segnify` instance can be configured.
@@ -36,7 +36,7 @@ extension PageViewControllerProtocol {
     
     /// Provide a default value.
     public var bannerViewClosure: BannerViewClosure {
-        return {}
+        return { _ in }
     }
     
     /// Provide a default value.

--- a/Segnify/Protocols/PageViewControllerProtocol.swift
+++ b/Segnify/Protocols/PageViewControllerProtocol.swift
@@ -33,20 +33,6 @@ extension PageViewControllerProtocol {
     
     /// Provide a default value.
     public var bannerViewClosure: BannerViewClosure {
-        return { superview in
-            // Create a blank view with a height of 0.0.
-            let blankView = UIView()
-            blankView.backgroundColor = .clear
-            
-            // Add as subview and add Auto Layout constraints.
-            superview.addSubview(blankView)
-            NSLayoutConstraint.activate([
-                blankView.topAnchor.constraint(equalTo: superview.topAnchor),
-                blankView.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-                blankView.bottomAnchor.constraint(equalTo: superview.bottomAnchor),
-                blankView.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
-                blankView.heightAnchor.constraint(equalToConstant: 0.0)
-                ], for: blankView)
-        }
+        return { _ in }
     }
 }

--- a/Segnify/Protocols/PageViewControllerProtocol.swift
+++ b/Segnify/Protocols/PageViewControllerProtocol.swift
@@ -18,6 +18,7 @@ public protocol PageViewControllerProtocol {
     /// Specifies the height of the `Segnify` component in `PageViewController`.
     /// The height will be realised using Auto Layout constraints.
     ///
-    /// Please note that this property specifies the height of the `Segnify` component including its footer view.
+    /// Please note that this property specifies the height of the `Segnify` component
+    /// without taking its footer view into account.
     var segnifyHeight: CGFloat { get }
 }

--- a/Segnify/Protocols/PageViewControllerProtocol.swift
+++ b/Segnify/Protocols/PageViewControllerProtocol.swift
@@ -33,6 +33,18 @@ extension PageViewControllerProtocol {
     
     /// Provide a default value.
     public var bannerViewClosure: BannerViewClosure {
-        return { _ in }
+        return { superview in
+            // Create a blank view with a height of 0.0.
+            let blankView = UIView()
+            blankView.backgroundColor = .clear
+            
+            NSLayoutConstraint.activate([
+                blankView.topAnchor.constraint(equalTo: superview.topAnchor),
+                blankView.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
+                blankView.bottomAnchor.constraint(equalTo: superview.bottomAnchor),
+                blankView.trailingAnchor.constraint(equalTo: superview.trailingAnchor),
+                blankView.heightAnchor.constraint(equalToConstant: 0.0)
+                ], for: blankView)
+        }
     }
 }

--- a/Segnify/Protocols/PageViewControllerProtocol.swift
+++ b/Segnify/Protocols/PageViewControllerProtocol.swift
@@ -17,5 +17,7 @@ public protocol PageViewControllerProtocol {
     
     /// Specifies the height of the `Segnify` component in `PageViewController`.
     /// The height will be realised using Auto Layout constraints.
+    ///
+    /// Please note that this property specifies the height of the `Segnify` component including its footer view.
     var segnifyHeight: CGFloat { get }
 }

--- a/Segnify/Protocols/PageViewControllerProtocol.swift
+++ b/Segnify/Protocols/PageViewControllerProtocol.swift
@@ -8,6 +8,10 @@
 
 import UIKit
 
+/// A closure for adding one or more subviews to the `bannerView` instance of `PageViewController`
+/// and adding Auto Layout constraints to them.
+public typealias BannerViewClosure = () -> ()
+
 /// Configure a `PageViewController` instance by implementing this protocol.
 /// The background color of the view and the height of its `Segnify` instance can be configured.
 public protocol PageViewControllerProtocol {
@@ -15,7 +19,28 @@ public protocol PageViewControllerProtocol {
     /// Specifies the background color of the main view.
     var backgroundColor: UIColor { get }
     
+    /// Add one or more subviews to the `bannerView` instance of `PageViewController`.
+    var bannerViewClosure: BannerViewClosure { get }
+    
+    /// Specifies the height of the `bannerView` instance.
+    var bannerViewHeight: CGFloat { get }
+    
     /// Specifies the height of the `Segnify` component in `PageViewController`.
     /// The height will be realised using Auto Layout constraints.
     var segnifyHeight: CGFloat { get }
+}
+
+// MARK: - Defaults
+
+extension PageViewControllerProtocol {
+    
+    /// Provide a default value.
+    public var bannerViewClosure: BannerViewClosure {
+        return {}
+    }
+    
+    /// Provide a default value.
+    public var bannerViewHeight: CGFloat {
+        return 0.0
+    }
 }

--- a/Segnify/Protocols/SegnicatorProtocol.swift
+++ b/Segnify/Protocols/SegnicatorProtocol.swift
@@ -8,14 +8,11 @@
 
 import UIKit
 
-/// A closure with a reference to a `Segnicator` instance, in order to add one or more subviews to that `Segnicator` instance.
-public typealias SegnicatorSubviewsClosure = (Segnicator) -> ()
-
 /// Customize the `Segnicator` appearance by implementing this protocol.
 public protocol SegnicatorProtocol {
     
-    /// Add one or more subviews to the `Segnicator` instance.
-    var segnicatorSubviewsClosure: SegnicatorSubviewsClosure { get }
+    /// Specifies the appearance of the `Segnicator` instance.
+    var segnicatorView: UIView { get }
 }
 
 // MARK: - Defaults
@@ -23,8 +20,7 @@ public protocol SegnicatorProtocol {
 extension SegnicatorProtocol {
     
     /// Provide a default value.
-    public var segnicatorSubviewsClosure: SegnicatorSubviewsClosure {
-        // Keeps the `Segnicator` instance free of subviews, thus empty.
-        return { _ in }
+    public var segnicatorView: UIView {
+        return UIView()
     }
 }

--- a/Segnify/Protocols/SegnifyEventsProtocol.swift
+++ b/Segnify/Protocols/SegnifyEventsProtocol.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// Get informed by `Segnify` events, i.e. segment selection, by implementing this protocol.
-public protocol SegnifyEventsProtocol {
+internal protocol SegnifyEventsProtocol {
 
     /// Inform the delegate about `Segment` selection changes.
     func didSelect(segment: Segment, of segnify: Segnify, previousIndex: Int?, currentIndex: Int)

--- a/Segnify/Protocols/SegnifyProtocol.swift
+++ b/Segnify/Protocols/SegnifyProtocol.swift
@@ -13,6 +13,12 @@ public protocol SegnifyProtocol {
     
     /// The background color of the main `Segnify` component.
     var backgroundColor: UIColor { get }
+    
+    /// Specifies an optional footer view below the `Segnify` instance.
+    var footerView: UIView { get }
+    
+    /// Specifies the height of the footer view below the `Segnify` instance.
+    var footerViewHeight: CGFloat { get }
 
     /// A Boolean value that determines whether bouncing always occurs when horizontal scrolling reaches the end of the scroll view.
     ///
@@ -40,6 +46,16 @@ public protocol SegnifyProtocol {
 // MARK: - Defaults
 
 extension SegnifyProtocol {
+    
+    /// Provide a default value.
+    public var footerView: UIView {
+        return UIView()
+    }
+    
+    /// Provide a default value.
+    public var footerViewHeight: CGFloat {
+        return 0.0
+    }
     
     /// Provide a default value.
     public var isBouncingHorizontally: Bool {

--- a/Segnify/Protocols/SegnifyProtocol.swift
+++ b/Segnify/Protocols/SegnifyProtocol.swift
@@ -16,9 +16,6 @@ public protocol SegnifyProtocol {
     
     /// Specifies an optional footer view below the `Segnify` instance.
     var footerView: UIView { get }
-    
-    /// Specifies the height of the footer view below the `Segnify` instance.
-    var footerViewHeight: CGFloat { get }
 
     /// A Boolean value that determines whether bouncing always occurs when horizontal scrolling reaches the end of the scroll view.
     ///
@@ -50,11 +47,6 @@ extension SegnifyProtocol {
     /// Provide a default value.
     public var footerView: UIView {
         return UIView()
-    }
-    
-    /// Provide a default value.
-    public var footerViewHeight: CGFloat {
-        return 0.0
     }
     
     /// Provide a default value.

--- a/Segnify/View Controllers/PageViewController.swift
+++ b/Segnify/View Controllers/PageViewController.swift
@@ -220,7 +220,7 @@ extension PageViewController: UIPageViewControllerDataSource {
         else if segnify.delegate?.isScrollingInfinitely == true {
             // When `previousIndex` becomes negative, the user wants to scroll backwards from the first page.
             // Show the last page.
-            viewControllerToReturn = contentElements.last!.viewController
+            viewControllerToReturn = contentElements.last?.viewController
         }
         else {
             // Nothing to return in this case, when `isScrollingInfinitely` is `false`.
@@ -258,7 +258,7 @@ extension PageViewController: UIPageViewControllerDataSource {
             // When `nextIndex` exceeds the number of available view controllers,
             // the user wants to scroll forwards from the last page.
             // Show the first page.
-            viewControllerToReturn = contentElements.first!.viewController
+            viewControllerToReturn = contentElements.first?.viewController
         }
         else {
             // Nothing to return in this case, when `isScrollingInfinitely` is `false`.

--- a/Segnify/View Controllers/PageViewController.swift
+++ b/Segnify/View Controllers/PageViewController.swift
@@ -13,9 +13,6 @@ open class PageViewController: UIViewController {
     
     // MARK: - Private variables
     
-    /// References the footer view below the `Segnify` instance.
-    private var footerView: UIView?
-    
     /// Maintains the height of the `Segnify` instance.
     private var segnifyHeightConstraint: NSLayoutConstraint?
     
@@ -48,26 +45,6 @@ open class PageViewController: UIViewController {
             if let delegate = delegate {
                 // Background color.
                 view.backgroundColor = delegate.backgroundColor
-                
-                // Delete the current footer view.
-                if let footerView = footerView {
-                    footerView.removeFromSuperview()
-                }
-                
-                // Add the new footer view.
-                footerView = delegate.footerView
-                view.addSubview(footerView!)
-                
-                // Add constraints.
-                if let pageView = pageViewController.view {
-                    NSLayoutConstraint.activate([
-                        footerView!.topAnchor.constraint(equalTo: segnify.bottomAnchor),
-                        footerView!.leadingAnchor.constraint(equalTo: view.leadingAnchor),
-                        footerView!.bottomAnchor.constraint(equalTo: pageView.topAnchor),
-                        footerView!.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                        footerView!.heightAnchor.constraint(equalToConstant: delegate.footerViewHeight)
-                        ], for: footerView!)
-                }
                 
                 // Update the height constraint ...
                 segnifyHeightConstraint?.constant = delegate.segnifyHeight
@@ -145,9 +122,9 @@ open class PageViewController: UIViewController {
         // Give it some Auto Layout constraints.
         segnifyHeightConstraint = segnify.heightAnchor.constraint(equalToConstant: delegate?.segnifyHeight ?? 0.0)
         NSLayoutConstraint.activate([
+            segnify.topAnchor.constraint(equalTo: topLayoutGuide.bottomAnchor),
             segnify.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             segnify.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            segnify.topAnchor.constraint(equalTo: topLayoutGuide.bottomAnchor),
             segnifyHeightConstraint!
             ], for: segnify)
         
@@ -159,9 +136,10 @@ open class PageViewController: UIViewController {
             
             // Give it some Auto Layout constraints.
             NSLayoutConstraint.activate([
+                pageView.topAnchor.constraint(equalTo: segnify.bottomAnchor),
                 pageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+                pageView.bottomAnchor.constraint(equalTo: bottomLayoutGuide.topAnchor),
                 pageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                pageView.bottomAnchor.constraint(equalTo: bottomLayoutGuide.topAnchor)
                 ], for: pageView)
         }
     }

--- a/Segnify/View Controllers/PageViewController.swift
+++ b/Segnify/View Controllers/PageViewController.swift
@@ -13,9 +13,6 @@ open class PageViewController: UIViewController {
     
     // MARK: - Private variables
     
-    /// Maintains the height of the `bannerView`.
-    private var bannerViewHeightConstraint: NSLayoutConstraint?
-    
     /// Maintains the height of the `Segnify` instance.
     private var segnifyHeightConstraint: NSLayoutConstraint?
     
@@ -59,13 +56,6 @@ open class PageViewController: UIViewController {
                 
                 // Banner view.
                 delegate.bannerViewClosure(bannerView)
-                
-                // Deactivate the banner view's height constraint.
-                // It's up to the user's `bannerViewClosure` to prevent Auto Layout warnings.
-                if let bannerViewHeightConstraint = bannerViewHeightConstraint {
-                    NSLayoutConstraint.deactivate([bannerViewHeightConstraint])
-                    self.bannerViewHeightConstraint = nil
-                }
                 
                 // Update the height constraint ...
                 segnifyHeightConstraint?.constant = delegate.segnifyHeight
@@ -153,12 +143,10 @@ open class PageViewController: UIViewController {
         view.addSubview(bannerView)
         
         // Give it some Auto Layout constraints.
-        bannerViewHeightConstraint = bannerView.heightAnchor.constraint(equalToConstant: 0.0)
         NSLayoutConstraint.activate([
             bannerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bannerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
             bannerView.topAnchor.constraint(equalTo: segnify.bottomAnchor),
-            bannerViewHeightConstraint!
             ], for: bannerView)
         
         // Add the page view controller.

--- a/Segnify/View Controllers/PageViewController.swift
+++ b/Segnify/View Controllers/PageViewController.swift
@@ -11,11 +11,6 @@ import UIKit
 /// The `PageViewController` controls and maintains both `Segnify` and `PageViewController` instances.
 open class PageViewController: UIViewController {
     
-    // MARK: - Private variables
-    
-    /// Maintains the height of the `Segnify` instance.
-    private var segnifyHeightConstraint: NSLayoutConstraint?
-    
     // MARK: - Public variables
     
     /// A `UIPageViewController` instance will show the main content, below the `Segnify` instance and, optionally, its footer view.
@@ -46,8 +41,8 @@ open class PageViewController: UIViewController {
                 // Background color.
                 view.backgroundColor = delegate.backgroundColor
                 
-                // Update the height constraint ...
-                segnifyHeightConstraint?.constant = delegate.segnifyHeight
+                // Update the height ...
+                segnify.height = delegate.segnifyHeight
                 // ... and trigger a layout update.
                 view.setNeedsLayout()
             }
@@ -120,12 +115,10 @@ open class PageViewController: UIViewController {
         view.addSubview(segnify)
         
         // Give it some Auto Layout constraints.
-        segnifyHeightConstraint = segnify.heightAnchor.constraint(equalToConstant: delegate?.segnifyHeight ?? 0.0)
         NSLayoutConstraint.activate([
             segnify.topAnchor.constraint(equalTo: topLayoutGuide.bottomAnchor),
             segnify.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             segnify.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            segnifyHeightConstraint!
             ], for: segnify)
         
         // Add the page view controller.

--- a/Segnify/View Controllers/PageViewController.swift
+++ b/Segnify/View Controllers/PageViewController.swift
@@ -37,8 +37,8 @@ open class PageViewController: UIViewController {
     /// A `Segnify` instance will be shown above the `bannerView`, showing all `Segment` instances.
     public lazy var segnify: Segnify = {
         let segnify = Segnify()
+        segnify.eventsDelegate = self
         segnify.segnicator = Segnicator(configuration: DefaultSegnicatorDelegate())
-        segnify.segnifyEventsDelegate = self
         return segnify
     }()
     
@@ -68,10 +68,10 @@ open class PageViewController: UIViewController {
         }
     }
     
-    /// The delegate object of `EventsProtocol` will be notified of various `Segnify` and `UIPageViewController` events.
-    public var eventsDelegate: EventsProtocol? {
+    /// The delegate object of `ForwardedEventsProtocol` will be notified of various `Segnify` and `UIPageViewController` events.
+    public var forwardedEventsDelegate: ForwardedEventsProtocol? {
         didSet {
-            segnify.eventsDelegate = eventsDelegate
+            segnify.forwardedEventsDelegate = forwardedEventsDelegate
         }
     }
     
@@ -227,9 +227,9 @@ extension PageViewController: UIPageViewControllerDataSource {
         }
         
         // Notify our 'custom' delegate.
-        eventsDelegate?.pageViewController(pageViewController,
-                                           requested: viewControllerToReturn,
-                                           before: viewController)
+        forwardedEventsDelegate?.pageViewController(pageViewController,
+                                                    requested: viewControllerToReturn,
+                                                    before: viewController)
         
         return viewControllerToReturn
     }
@@ -265,9 +265,9 @@ extension PageViewController: UIPageViewControllerDataSource {
         }
         
         // Notify our 'custom' delegate.
-        eventsDelegate?.pageViewController(pageViewController,
-                                           requested: viewControllerToReturn,
-                                           after: viewController)
+        forwardedEventsDelegate?.pageViewController(pageViewController,
+                                                    requested: viewControllerToReturn,
+                                                    after: viewController)
         
         return viewControllerToReturn
     }
@@ -280,7 +280,7 @@ extension PageViewController: UIPageViewControllerDelegate {
     public func pageViewController(_ pageViewController: UIPageViewController,
                                    willTransitionTo pendingViewControllers: [UIViewController]) {
         // Notify our 'custom' delegate.
-        eventsDelegate?.pageViewController(pageViewController, willTransitionTo: pendingViewControllers)
+        forwardedEventsDelegate?.pageViewController(pageViewController, willTransitionTo: pendingViewControllers)
     }
     
     public func pageViewController(_ pageViewController: UIPageViewController,
@@ -293,10 +293,10 @@ extension PageViewController: UIPageViewControllerDelegate {
         }
         
         // Notify our 'custom' delegate.
-        eventsDelegate?.pageViewController(pageViewController,
-                                           didFinishAnimating: finished,
-                                           previousViewControllers: previousViewControllers,
-                                           transitionCompleted: completed)
+        forwardedEventsDelegate?.pageViewController(pageViewController,
+                                                    didFinishAnimating: finished,
+                                                    previousViewControllers: previousViewControllers,
+                                                    transitionCompleted: completed)
         
         if let indexOfCurrentViewController = firstIndexOf(currentViewController) {
             // Switch segment.

--- a/Segnify/View Controllers/PageViewController.swift
+++ b/Segnify/View Controllers/PageViewController.swift
@@ -13,12 +13,23 @@ open class PageViewController: UIViewController {
     
     // MARK: - Private variables
     
+    /// Maintains the height of the `bannerView`.
+    private var bannerViewHeightConstraint: NSLayoutConstraint?
+    
     /// Maintains the height of the `Segnify` instance.
     private var segnifyHeightConstraint: NSLayoutConstraint?
     
     // MARK: - Public variables
     
-    /// A `UIPageViewController` instance will shown the main content, below the `Segnify` instance.
+    /// The `bannerView`, which is just a `UIView` instance, will be shown in between
+    /// the `Segnify` instance and the `PageViewController` instance.
+    public private(set) var bannerView: UIView = {
+        let bannerView = UIView()
+        bannerView.backgroundColor = .clear
+        return bannerView
+    }()
+    
+    /// A `UIPageViewController` instance will show the main content, below the `bannerView`.
     public lazy var pageViewController: UIPageViewController = {
         let pageViewController = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
         pageViewController.dataSource = self
@@ -26,13 +37,15 @@ open class PageViewController: UIViewController {
         return pageViewController
     }()
     
-    /// A `Segnify` instance will be shown above the `PageViewController` instance, showing all `Segment` instances.
+    /// A `Segnify` instance will be shown above the `bannerView`, showing all `Segment` instances.
     public lazy var segnify: Segnify = {
         let segnify = Segnify()
         segnify.segnicator = Segnicator(configuration: DefaultSegnicatorDelegate())
         segnify.segnifyEventsDelegate = self
         return segnify
     }()
+    
+    // MARK: - Delegates
     
     /// The delegate object of `SegnifyDataSourceProtocol` specifies the content for the `Segnify` instance and this `PageViewController` instance.
     public private(set) var dataSource: SegnifyDataSourceProtocol?
@@ -126,6 +139,18 @@ open class PageViewController: UIViewController {
             segnifyHeightConstraint!
             ], for: segnify)
         
+        // Load up the banner view.
+        view.addSubview(bannerView)
+        
+        // Give it some Auto Layout constraints.
+        bannerViewHeightConstraint = bannerView.heightAnchor.constraint(equalToConstant: delegate?.bannerViewHeight ?? 0.0)
+        NSLayoutConstraint.activate([
+            bannerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            bannerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            bannerView.topAnchor.constraint(equalTo: segnify.bottomAnchor),
+            bannerViewHeightConstraint!
+            ], for: bannerView)
+        
         // Add the page view controller.
         if let pageView = pageViewController.view {
             addChild(pageViewController)
@@ -136,7 +161,7 @@ open class PageViewController: UIViewController {
             NSLayoutConstraint.activate([
                 pageView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
                 pageView.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-                pageView.topAnchor.constraint(equalTo: segnify.bottomAnchor),
+                pageView.topAnchor.constraint(equalTo: bannerView.bottomAnchor),
                 pageView.bottomAnchor.constraint(equalTo: bottomLayoutGuide.topAnchor)
                 ], for: pageView)
         }

--- a/Segnify/View Controllers/PageViewController.swift
+++ b/Segnify/View Controllers/PageViewController.swift
@@ -54,8 +54,18 @@ open class PageViewController: UIViewController {
     public var delegate: PageViewControllerProtocol? {
         didSet {
             if let delegate = delegate {
-                // Set the background color.
+                // Background color.
                 view.backgroundColor = delegate.backgroundColor
+                
+                // Banner view.
+                delegate.bannerViewClosure(bannerView)
+                
+                // Deactivate the banner view's height constraint.
+                // It's up to the user's `bannerViewClosure` to prevent Auto Layout warnings.
+                if let bannerViewHeightConstraint = bannerViewHeightConstraint {
+                    NSLayoutConstraint.deactivate([bannerViewHeightConstraint])
+                    self.bannerViewHeightConstraint = nil
+                }
                 
                 // Update the height constraint ...
                 segnifyHeightConstraint?.constant = delegate.segnifyHeight
@@ -143,7 +153,7 @@ open class PageViewController: UIViewController {
         view.addSubview(bannerView)
         
         // Give it some Auto Layout constraints.
-        bannerViewHeightConstraint = bannerView.heightAnchor.constraint(equalToConstant: delegate?.bannerViewHeight ?? 0.0)
+        bannerViewHeightConstraint = bannerView.heightAnchor.constraint(equalToConstant: 0.0)
         NSLayoutConstraint.activate([
             bannerView.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             bannerView.trailingAnchor.constraint(equalTo: view.trailingAnchor),

--- a/Segnify/View Controllers/PageViewController.swift
+++ b/Segnify/View Controllers/PageViewController.swift
@@ -55,6 +55,9 @@ open class PageViewController: UIViewController {
                 view.backgroundColor = delegate.backgroundColor
                 
                 // Banner view.
+                for subview in bannerView.subviews {
+                    subview.removeFromSuperview()
+                }
                 delegate.bannerViewClosure(bannerView)
                 
                 // Update the height constraint ...

--- a/Segnify/Views/Segnicator.swift
+++ b/Segnify/Views/Segnicator.swift
@@ -18,7 +18,15 @@ open class Segnicator: UIView {
         didSet {
             if let configuration = configuration {
                 // Apply the segnicator configuration.
-                configuration.segnicatorSubviewsClosure(self)
+                let segnicatorView = configuration.segnicatorView
+                addSubview(segnicatorView)
+                // Apply Auto Layout constraints.
+                NSLayoutConstraint.activate([
+                    segnicatorView.topAnchor.constraint(equalTo: topAnchor),
+                    segnicatorView.leadingAnchor.constraint(equalTo: leadingAnchor),
+                    segnicatorView.bottomAnchor.constraint(equalTo: bottomAnchor),
+                    segnicatorView.trailingAnchor.constraint(equalTo: trailingAnchor)
+                    ], for: segnicatorView)
             }
         }
     }

--- a/Segnify/Views/Segnify.swift
+++ b/Segnify/Views/Segnify.swift
@@ -13,6 +13,9 @@ open class Segnify: UIView {
 
     // MARK: - Private variables
     
+    /// References the footer view below the `Segnify` instance.
+    private var footerView: UIView?
+    
     /// The width of every `Segment` instance.
     private var segmentWidth: CGFloat = 0.0
     
@@ -73,6 +76,9 @@ open class Segnify: UIView {
                 if !delegate.isEquallyFillingHorizontalSpace {
                     segmentWidth = delegate.segmentWidth
                 }
+                
+                // Footer view.
+                setupFooterViewIfNeeded()
             }
         }
     }
@@ -159,6 +165,7 @@ open class Segnify: UIView {
         
         setupSubviews()
         setupAutoLayoutConstraints()
+        setupFooterViewIfNeeded()
     }
     
     private func calculateSegmentWidth(_ superview: UIView?) {
@@ -184,7 +191,6 @@ open class Segnify: UIView {
             NSLayoutConstraint.activate([
                 scrollView.topAnchor.constraint(equalTo: superview.topAnchor),
                 scrollView.leadingAnchor.constraint(equalTo: superview.leadingAnchor),
-                scrollView.bottomAnchor.constraint(equalTo: superview.bottomAnchor),
                 scrollView.trailingAnchor.constraint(equalTo: superview.trailingAnchor)
                 ], for: scrollView)
         }
@@ -203,6 +209,46 @@ open class Segnify: UIView {
                 stackViewWidthConstraint!
                 ], for: stackView)
         }
+    }
+    
+    private func setupFooterViewIfNeeded() {
+        // We need a delegate
+        guard let delegate = delegate else {
+            return
+        }
+        
+        // No need to add it again.
+        guard delegate.footerView.superview == nil else {
+            return
+        }
+        
+        // Delete the current footer view.
+        footerView?.removeFromSuperview()
+        
+        // Assign the new footer view.
+        footerView = delegate.footerView
+        
+        // Sanity check.
+        guard let currentFooterView = footerView else {
+            return
+        }
+        
+        // Footer view will be connected to the scroll view.
+        guard scrollView.superview != nil else {
+            return
+        }
+        
+        // Add the new footer view.
+        addSubview(currentFooterView)
+        
+        // Add constraints.
+        NSLayoutConstraint.activate([
+            currentFooterView.topAnchor.constraint(equalTo: scrollView.bottomAnchor),
+            currentFooterView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+            currentFooterView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            currentFooterView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+            currentFooterView.heightAnchor.constraint(equalToConstant: delegate.footerViewHeight)
+            ], for: currentFooterView)
     }
 }
 

--- a/Segnify/Views/Segnify.swift
+++ b/Segnify/Views/Segnify.swift
@@ -247,7 +247,6 @@ open class Segnify: UIView {
             currentFooterView.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
             currentFooterView.bottomAnchor.constraint(equalTo: bottomAnchor),
             currentFooterView.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
-            currentFooterView.heightAnchor.constraint(equalToConstant: delegate.footerViewHeight)
             ], for: currentFooterView)
     }
 }

--- a/Segnify/Views/Segnify.swift
+++ b/Segnify/Views/Segnify.swift
@@ -52,7 +52,12 @@ open class Segnify: UIView {
         return stackView
     }()
     
-    // MARK: - Delegates
+    // MARK: - Internal delegates
+    
+    /// The `SegnifyEventsProtocol` implementing delegate will be notified if a `Segment` instance has been selected.
+    internal var eventsDelegate: SegnifyEventsProtocol?
+    
+    // MARK: - Public delegates
     
     /// The `SegnifyDataSourceProtocol` implementing delegate will define the titles for the `Segment` instances of `Segnify`.
     public var dataSource: SegnifyDataSourceProtocol?
@@ -72,11 +77,8 @@ open class Segnify: UIView {
         }
     }
     
-    /// The `EventsProtocol` implementing delegate will be notified if a `Segment` instance has been selected.
-    public var eventsDelegate: EventsProtocol?
-    
-    /// The `SegnifyEventsProtocol` implementing delegate will be notified if a `Segment` instance has been selected.
-    public var segnifyEventsDelegate: SegnifyEventsProtocol?
+    /// The `ForwardedEventsProtocol` implementing delegate will be notified if a `Segment` instance has been selected.
+    public var forwardedEventsDelegate: ForwardedEventsProtocol?
     
     // MARK: - Segnicator
     
@@ -153,7 +155,7 @@ open class Segnify: UIView {
                        eventsDelegate: SegnifyEventsProtocol? = nil) {
         self.dataSource = dataSource
         self.delegate = delegate
-        self.segnifyEventsDelegate = eventsDelegate
+        self.eventsDelegate = eventsDelegate
         
         setupSubviews()
         setupAutoLayoutConstraints()
@@ -319,11 +321,11 @@ extension Segnify {
             currentIndex = stackView.arrangedSubviews.firstIndex(of: selectedSegment)!
             
             // Notify the events delegates.
-            segnifyEventsDelegate?.didSelect(segment: selectedSegment,
-                                             of: self,
-                                             previousIndex: previousIndex,
-                                             currentIndex: currentIndex)
-            eventsDelegate?.segnify(self, receivedTouchInside: selectedSegment)
+            eventsDelegate?.didSelect(segment: selectedSegment,
+                                      of: self,
+                                      previousIndex: previousIndex,
+                                      currentIndex: currentIndex)
+            forwardedEventsDelegate?.segnify(self, receivedTouchInside: selectedSegment)
         }
     }
 }

--- a/Segnify/Views/Segnify.swift
+++ b/Segnify/Views/Segnify.swift
@@ -312,16 +312,19 @@ extension Segnify {
         
         // The segment wants to be selected.
         handleSegmentSelection(with: segment)
-
-        // Set the current index.
-        currentIndex = stackView.arrangedSubviews.firstIndex(of: selectedSegment!)!
         
-        // Notify the events delegates.
-        segnifyEventsDelegate?.didSelect(segment: selectedSegment!,
-                                  of: self,
-                                  previousIndex: previousIndex,
-                                  currentIndex: currentIndex)
-        eventsDelegate?.segnify(self, receivedTouchInside: selectedSegment!)
+        // Sanity check.
+        if let selectedSegment = selectedSegment {
+            // Set the current index.
+            currentIndex = stackView.arrangedSubviews.firstIndex(of: selectedSegment)!
+            
+            // Notify the events delegates.
+            segnifyEventsDelegate?.didSelect(segment: selectedSegment,
+                                             of: self,
+                                             previousIndex: previousIndex,
+                                             currentIndex: currentIndex)
+            eventsDelegate?.segnify(self, receivedTouchInside: selectedSegment)
+        }
     }
 }
 

--- a/Segnify/Views/Segnify.swift
+++ b/Segnify/Views/Segnify.swift
@@ -16,6 +16,10 @@ open class Segnify: UIView {
     /// References the footer view below the `Segnify` instance.
     private var footerView: UIView?
     
+    /// Maintains the actual height of the `scrollView` instance.
+    /// It specifies the height of the `Segnify` instance without bothering any footer view.
+    private var heightConstraint: NSLayoutConstraint?
+    
     /// The width of every `Segment` instance.
     private var segmentWidth: CGFloat = 0.0
     
@@ -33,6 +37,29 @@ open class Segnify: UIView {
     private var stackViewWidthConstraint: NSLayoutConstraint?
     
     // MARK: - Public variables
+    
+    /// Maintains the height of the `Segnify` instance, without taking the footer view into account.
+    ///
+    /// When the `Segnify` instance has a height of X, and the footer view a height of Y,
+    /// the total height of the `Segnify` view will be X + Y.
+    public var height: CGFloat? {
+        didSet {
+            // Deactivate the old one.
+            if let heightConstraint = heightConstraint {
+                NSLayoutConstraint.deactivate([heightConstraint])
+            }
+            
+            // Set the new height (constraint).
+            if let height = height {
+                heightConstraint = scrollView.heightAnchor.constraint(equalToConstant: height)
+            }
+            
+            // Activate.
+            if let heightConstraint = heightConstraint {
+                NSLayoutConstraint.activate([heightConstraint], for: scrollView)
+            }
+        }
+    }
     
     /// The top level scroll view, which makes Segnify horizontally scroll.
     public private(set) lazy var scrollView: UIScrollView = {
@@ -165,7 +192,6 @@ open class Segnify: UIView {
         
         setupSubviews()
         setupAutoLayoutConstraints()
-        setupFooterViewIfNeeded()
     }
     
     private func calculateSegmentWidth(_ superview: UIView?) {


### PR DESCRIPTION
***Context***
The Dossier app uses a `BannerView` to show important data related to the client in the detail view.
Support for this `BannerView` has now been added.

***Relevant issues***
#11 
Depends on #8 

***Changes***
- What does it do?
It gives the user the possibility to add one or more subviews between the `Segnify` instance and the `UIPageViewController` instance, in order to support the `BannerView`.

![simulator screen shot - iphone 8 - 2018-12-03 at 12 04 37](https://user-images.githubusercontent.com/598682/49370288-07e98e00-f6f4-11e8-83f6-e7fa103ace73.png)

***Check-list***
- [ ] Acceptance criteria in issue satisfied or Bug fixed
- [ ] Documentation present (relevant information is properly documented)
- [ ] Written tests for test suite (optional for the moment)
- [ ] Tested on devices
- [ ] CHANGELOG updated