### PR TITLE
Made references weak and turned structs into classes where necessary.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,18 @@ All notable changes to this project will be documented in this file.
 `Segnify` adheres to [Semantic Versioning](https://semver.org/).
 
 #### 1.x Releases
-- `1.1.x` Releases - [1.1.0](#110) | [1.1.1](#111)
+- `1.1.x` Releases - [1.1.0](#110) | [1.1.1](#111) | [1.1.2](#112)
 - `1.0.x` Releases - [1.0.0](#100) | [1.0.1](#101) | [1.0.2](#102)
 
 ---
+## [1.1.2](https://github.com/nedap/Segnify/releases/tag/1.1.2)
+Released on 2018-12-XX.
+
+#### Fixed
+
+- Fixed weak references to unowned objects ([#14](https://github.com/nedap/Segnify/issues/14))
+  - Fixed by [Bart Hopster](https://github.com/barthopster).
+
 ## [1.1.1](https://github.com/nedap/Segnify/releases/tag/1.1.1)
 Released on 2018-12-13.
 

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ The protocol partly relies on the `UIPageViewControllerDataSource` and `UIPageVi
 Implement `ImageSegmentProtocol` for customizing image segments. In the example below, the default implementation in [DefaultImageSegmentDelegate](Segnify/Protocols/Defaults/DefaultImageSegmentDelegate.swift) is being shown.
 
 ```swift
-public struct DefaultImageSegmentDelegate: ImageSegmentProtocol {
+public class DefaultImageSegmentDelegate: ImageSegmentProtocol {
     
     // MARK: - Delegate
     
@@ -225,7 +225,7 @@ public struct DefaultImageSegmentDelegate: ImageSegmentProtocol {
 Implement `PageViewControllerProtocol` for visually customizing the `PageViewController` instance. In the example below, the default implementation in [DefaultPageViewControllerDelegate](Segnify/Protocols/Defaults/DefaultPageViewControllerDelegate.swift) is being shown.
 
 ```swift
-public struct DefaultPageViewControllerDelegate: PageViewControllerProtocol {
+public class DefaultPageViewControllerDelegate: PageViewControllerProtocol {
     
     // MARK: - Delegate
     
@@ -246,7 +246,7 @@ Implement `SegnicatorProtocol` for visually customizing the `Segnicator` instanc
 A white, horizontal line is created and added as a subview. Auto Layout constraints have been applied using the `SegnifyLayoutConstraint` extension.
 
 ```swift
-public struct DefaultSegnicatorDelegate: SegnicatorProtocol {
+public class DefaultSegnicatorDelegate: SegnicatorProtocol {
 
     // MARK: - Delegate
     
@@ -319,7 +319,7 @@ public class DefaultSegnifyDataSourceDelegate: SegnifyDataSourceProtocol {
 Implement `SegnifyProtocol` for visually customizing the `Segnify` instance. In the example below, the default implementation in [DefaultSegnifyDelegate](Segnify/Protocols/Defaults/DefaultSegnifyDelegate.swift) is being shown.
 
 ```swift
-public struct DefaultSegnifyDelegate: SegnifyProtocol {
+public class DefaultSegnifyDelegate: SegnifyProtocol {
 
     // MARK: - Delegate
     
@@ -342,7 +342,7 @@ public struct DefaultSegnifyDelegate: SegnifyProtocol {
 Implement `TextSegmentProtocol` for customizing textual segments. In the example below, the default implementation in [DefaultTextSegmentDelegate](Segnify/Protocols/Defaults/DefaultTextSegmentDelegate.swift) is being shown.
 
 ```swift
-public struct DefaultTextSegmentDelegate: TextSegmentProtocol {
+public class DefaultTextSegmentDelegate: TextSegmentProtocol {
     
     // MARK: - Delegate
     

--- a/Segnified/Delegates/ImageSegmentDelegate.swift
+++ b/Segnified/Delegates/ImageSegmentDelegate.swift
@@ -9,17 +9,17 @@
 import Segnify
 
 /// Implements `ImageSegmentProtocol`.
-struct ImageSegmentDelegate: ImageSegmentProtocol {
+public class ImageSegmentDelegate: ImageSegmentProtocol {
     
     // MARK: - Delegate
     
-    func backgroundColor(for state: UIControl.State) -> UIColor {
+    public func backgroundColor(for state: UIControl.State) -> UIColor {
         return .nedapOrange
     }
     
-    var imageViewEdgeInsets: UIEdgeInsets {
+    public var imageViewEdgeInsets: UIEdgeInsets {
         return .init(top: 10.0, left: 10.0, bottom: 10.0, right: 10.0)
     }
     
-    var tintColor: UIColor? = .nedapDarkBlue
+    public var tintColor: UIColor? = .nedapDarkBlue
 }

--- a/Segnified/Delegates/PageViewControllerDelegate.swift
+++ b/Segnified/Delegates/PageViewControllerDelegate.swift
@@ -9,11 +9,11 @@
 import Segnify
 
 /// Implements `PageViewControllerProtocol`.
-struct PageViewControllerDelegate: PageViewControllerProtocol {
+public class PageViewControllerDelegate: PageViewControllerProtocol {
     
     // MARK: - Delegate
     
-    var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .white
     
-    var segnifyHeight: CGFloat = 75.0
+    public var segnifyHeight: CGFloat = 75.0
 }

--- a/Segnified/Delegates/SegnicatorDelegate.swift
+++ b/Segnified/Delegates/SegnicatorDelegate.swift
@@ -9,11 +9,11 @@
 import Segnify
 
 /// Implements `SegnicatorProtocol`.
-struct SegnicatorDelegate: SegnicatorProtocol {
+public class SegnicatorDelegate: SegnicatorProtocol {
     
     // MARK: - Delegate
     
-    var segnicatorView: UIView {
+    public var segnicatorView: UIView {
         // Create a white, half-transparent background view.
         let backgroundView = UIView()
         backgroundView.backgroundColor = .init(white: 1.0, alpha: 0.4)

--- a/Segnified/Delegates/SegnifyDelegate.swift
+++ b/Segnified/Delegates/SegnifyDelegate.swift
@@ -38,7 +38,14 @@ public class SegnifyDelegate: SegnifyProtocol {
         return footerView
     }
     
-    public var isEquallyFillingHorizontalSpace: Bool = false
+    public var isEquallyFillingHorizontalSpace: Bool {
+        // Show all segments at once on iPad.
+        return UIDevice.current.userInterfaceIdiom == .pad ? true : false
+    }
     
-    public var segmentWidth: CGFloat = 175.0
+    public var segmentWidth: CGFloat {
+        // Show three segments and a bit of the fourth on iPhone.
+        // For iPad, this value will be ignored, because of `isEquallyFillingHorizontalSpace`.
+        return (UIScreen.main.bounds.width / 3) * 0.80
+    }
 }

--- a/Segnified/Delegates/SegnifyDelegate.swift
+++ b/Segnified/Delegates/SegnifyDelegate.swift
@@ -9,13 +9,13 @@
 import Segnify
 
 /// Implements `SegnifyProtocol`.
-struct SegnifyDelegate: SegnifyProtocol {
+public class SegnifyDelegate: SegnifyProtocol {
     
     // MARK: - Delegate
     
-    var backgroundColor: UIColor = .white
+    public var backgroundColor: UIColor = .white
     
-    var footerView: UIView {
+    public var footerView: UIView {
         // Create a footer view ...
         let footerView = UIView()
         footerView.backgroundColor = .lightGray
@@ -38,7 +38,7 @@ struct SegnifyDelegate: SegnifyProtocol {
         return footerView
     }
     
-    var isEquallyFillingHorizontalSpace: Bool = false
+    public var isEquallyFillingHorizontalSpace: Bool = false
     
-    var segmentWidth: CGFloat = 175.0
+    public var segmentWidth: CGFloat = 175.0
 }

--- a/Segnified/Delegates/TextSegmentDelegate.swift
+++ b/Segnified/Delegates/TextSegmentDelegate.swift
@@ -9,17 +9,17 @@
 import Segnify
 
 /// Implements `TextSegmentProtocol`.
-struct TextSegmentDelegate: TextSegmentProtocol {
+public class TextSegmentDelegate: TextSegmentProtocol {
     
     // MARK: - Delegate
     
-    func backgroundColor(for state: UIControl.State) -> UIColor {
+    public func backgroundColor(for state: UIControl.State) -> UIColor {
         return .nedapOrange
     }
     
-    var font: UIFont = .systemFont(ofSize: 17.0)
+    public var font: UIFont = .systemFont(ofSize: 17.0)
     
-    func textColor(for state: UIControl.State) -> UIColor {
+    public func textColor(for state: UIControl.State) -> UIColor {
         return .nedapDarkBlue
     }
 }

--- a/Segnified/View Controllers/PageViewContentViewController.swift
+++ b/Segnified/View Controllers/PageViewContentViewController.swift
@@ -8,7 +8,7 @@
 
 import Segnify
 
-class PageViewContentViewController: UIViewController {
+public class PageViewContentViewController: UIViewController {
     
     // MARK: - Private variables
     
@@ -31,7 +31,7 @@ class PageViewContentViewController: UIViewController {
 
     // MARK: - View lifecycle
     
-    override func viewDidLoad() {
+    override public func viewDidLoad() {
         super.viewDidLoad()
 
         // Background color.

--- a/Segnify/Protocols/Defaults/DefaultImageSegmentDelegate.swift
+++ b/Segnify/Protocols/Defaults/DefaultImageSegmentDelegate.swift
@@ -7,7 +7,7 @@
 //
 
 /// Provides a default implementation for `ImageSegmentProtocol`.
-public struct DefaultImageSegmentDelegate: ImageSegmentProtocol {
+public class DefaultImageSegmentDelegate: ImageSegmentProtocol {
     
     // MARK: - Delegate
     

--- a/Segnify/Protocols/Defaults/DefaultPageViewControllerDelegate.swift
+++ b/Segnify/Protocols/Defaults/DefaultPageViewControllerDelegate.swift
@@ -7,7 +7,7 @@
 //
 
 /// Provides a default implementation for `PageViewControllerProtocol`.
-public struct DefaultPageViewControllerDelegate: PageViewControllerProtocol {
+public class DefaultPageViewControllerDelegate: PageViewControllerProtocol {
     
     // MARK: - Delegate
     

--- a/Segnify/Protocols/Defaults/DefaultSegnicatorDelegate.swift
+++ b/Segnify/Protocols/Defaults/DefaultSegnicatorDelegate.swift
@@ -7,7 +7,7 @@
 //
 
 /// Provides a default implementation for `SegnicatorProtocol`.
-public struct DefaultSegnicatorDelegate: SegnicatorProtocol {
+public class DefaultSegnicatorDelegate: SegnicatorProtocol {
 
     // MARK: - Delegate
     

--- a/Segnify/Protocols/Defaults/DefaultSegnifyDelegate.swift
+++ b/Segnify/Protocols/Defaults/DefaultSegnifyDelegate.swift
@@ -7,7 +7,7 @@
 //
 
 /// Provides a default implementation for `SegnifyProtocol`.
-public struct DefaultSegnifyDelegate: SegnifyProtocol {
+public class DefaultSegnifyDelegate: SegnifyProtocol {
 
     // MARK: - Delegate
     

--- a/Segnify/Protocols/Defaults/DefaultTextSegmentDelegate.swift
+++ b/Segnify/Protocols/Defaults/DefaultTextSegmentDelegate.swift
@@ -7,7 +7,7 @@
 //
 
 /// Provides a default implementation for `TextSegmentProtocol`.
-public struct DefaultTextSegmentDelegate: TextSegmentProtocol {
+public class DefaultTextSegmentDelegate: TextSegmentProtocol {
     
     // MARK: - Delegate
     

--- a/Segnify/Protocols/ForwardedEventsProtocol.swift
+++ b/Segnify/Protocols/ForwardedEventsProtocol.swift
@@ -18,7 +18,7 @@ import UIKit
 ///
 /// The protocol partly relies on the `UIPageViewControllerDataSource` and `UIPageViewControllerDelegate` protocols.
 /// In this way, the implementations in `PageViewController` aren't at risk.
-public protocol ForwardedEventsProtocol {
+public protocol ForwardedEventsProtocol: class {
     
     /// Based on the corresponding `UIPageViewControllerDataSource` protocol, this method returns both the view controller
     /// before the currently viewed view controller, where the user navigated away from, and the latter view controller.

--- a/Segnify/Protocols/PageViewControllerProtocol.swift
+++ b/Segnify/Protocols/PageViewControllerProtocol.swift
@@ -10,7 +10,7 @@ import UIKit
 
 /// Configure a `PageViewController` instance by implementing this protocol.
 /// The background color of the view and the height of its `Segnify` instance can be configured.
-public protocol PageViewControllerProtocol {
+public protocol PageViewControllerProtocol: class {
     
     /// Specifies the background color of the main view.
     var backgroundColor: UIColor { get }

--- a/Segnify/Protocols/SegmentProtocol.swift
+++ b/Segnify/Protocols/SegmentProtocol.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// Customize any `Segment` appearance by implementing this protocol.
-public protocol SegmentProtocol {
+public protocol SegmentProtocol: class {
 
     /// The background color of the `Segment` instance for the different states.
     func backgroundColor(for state: UIControl.State) -> UIColor

--- a/Segnify/Protocols/SegnicatorProtocol.swift
+++ b/Segnify/Protocols/SegnicatorProtocol.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// Customize the `Segnicator` appearance by implementing this protocol.
-public protocol SegnicatorProtocol {
+public protocol SegnicatorProtocol: class {
     
     /// Specifies the appearance of the `Segnicator` instance.
     var segnicatorView: UIView { get }

--- a/Segnify/Protocols/SegnifyDataSourceProtocol.swift
+++ b/Segnify/Protocols/SegnifyDataSourceProtocol.swift
@@ -12,7 +12,7 @@ import UIKit
 public typealias SegnifyContentElement = (segment: Segment, viewController: UIViewController)
 
 /// Define the data source objects for your `Segnify` instance.
-public protocol SegnifyDataSourceProtocol {
+public protocol SegnifyDataSourceProtocol: class {
     
     /// The `SegnifyContentElement` instances to be shown.
     /// This array shouldn't be empty in order to have a functional `Segnify` instance.

--- a/Segnify/Protocols/SegnifyEventsProtocol.swift
+++ b/Segnify/Protocols/SegnifyEventsProtocol.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// Get informed by `Segnify` events, i.e. segment selection, by implementing this protocol.
-internal protocol SegnifyEventsProtocol {
+internal protocol SegnifyEventsProtocol: class {
 
     /// Inform the delegate about `Segment` selection changes.
     func didSelect(segment: Segment, of segnify: Segnify, previousIndex: Int?, currentIndex: Int)

--- a/Segnify/Protocols/SegnifyProtocol.swift
+++ b/Segnify/Protocols/SegnifyProtocol.swift
@@ -9,7 +9,7 @@
 import UIKit
 
 /// Customize the `Segnify` appearance by implementing this protocol.
-public protocol SegnifyProtocol {
+public protocol SegnifyProtocol: class {
     
     /// The background color of the main `Segnify` component.
     var backgroundColor: UIColor { get }

--- a/Segnify/View Controllers/PageViewController.swift
+++ b/Segnify/View Controllers/PageViewController.swift
@@ -32,10 +32,10 @@ open class PageViewController: UIViewController {
     // MARK: - Delegates
     
     /// The delegate object of `SegnifyDataSourceProtocol` specifies the content for the `Segnify` instance and this `PageViewController` instance.
-    public private(set) var dataSource: SegnifyDataSourceProtocol?
+    public private(set) weak var dataSource: SegnifyDataSourceProtocol?
     
     /// The delegate object of `PageViewControllerProtocol` offers customization possibilities for this `PageViewController` instance.
-    public var delegate: PageViewControllerProtocol? {
+    public weak var delegate: PageViewControllerProtocol? {
         didSet {
             if let delegate = delegate {
                 // Background color.
@@ -50,7 +50,7 @@ open class PageViewController: UIViewController {
     }
     
     /// The delegate object of `ForwardedEventsProtocol` will be notified of various `Segnify` and `UIPageViewController` events.
-    public var forwardedEventsDelegate: ForwardedEventsProtocol? {
+    public weak var forwardedEventsDelegate: ForwardedEventsProtocol? {
         didSet {
             segnify.forwardedEventsDelegate = forwardedEventsDelegate
         }

--- a/Segnify/Views/ImageSegment.swift
+++ b/Segnify/Views/ImageSegment.swift
@@ -21,7 +21,7 @@ open class ImageSegment: Segment {
     }
     
     /// Sets the `ImageSegmentConfiguration` to configure the segment's appearance.
-    override open var configuration: SegmentProtocol? {
+    override open weak var configuration: SegmentProtocol? {
         didSet {
             if let configuration = configuration as? ImageSegmentProtocol {
                 // Apply the image segment configuration.

--- a/Segnify/Views/Segment.swift
+++ b/Segnify/Views/Segment.swift
@@ -14,7 +14,7 @@ open class Segment: UIButton {
     
     // MARK: - Public variables
     
-    open var configuration: SegmentProtocol?
+    open weak var configuration: SegmentProtocol?
     
     // MARK: - UIButton methods
     

--- a/Segnify/Views/Segnicator.swift
+++ b/Segnify/Views/Segnicator.swift
@@ -14,7 +14,7 @@ open class Segnicator: UIView {
 
     // MARK: - Public variables
     
-    open var configuration: SegnicatorProtocol? {
+    open weak var configuration: SegnicatorProtocol? {
         didSet {
             if let configuration = configuration {
                 // Apply the segnicator configuration.

--- a/Segnify/Views/Segnify.swift
+++ b/Segnify/Views/Segnify.swift
@@ -199,6 +199,9 @@ open class Segnify: UIView {
         if let superview = superview, delegate?.isEquallyFillingHorizontalSpace == true, let contentElements = dataSource?.contentElements {
             segmentWidth = superview.bounds.maxX / CGFloat(contentElements.count)
         }
+        else if delegate?.isEquallyFillingHorizontalSpace == false, let newSegmentWidth = delegate?.segmentWidth {
+            segmentWidth = newSegmentWidth
+        }
     }
     
     // MARK: - Subviews & constraints

--- a/Segnify/Views/Segnify.swift
+++ b/Segnify/Views/Segnify.swift
@@ -85,15 +85,15 @@ open class Segnify: UIView {
     // MARK: - Internal delegates
     
     /// The `SegnifyEventsProtocol` implementing delegate will be notified if a `Segment` instance has been selected.
-    internal var eventsDelegate: SegnifyEventsProtocol?
+    internal weak var eventsDelegate: SegnifyEventsProtocol?
     
     // MARK: - Public delegates
     
     /// The `SegnifyDataSourceProtocol` implementing delegate will define the titles for the `Segment` instances of `Segnify`.
-    public var dataSource: SegnifyDataSourceProtocol?
+    public weak var dataSource: SegnifyDataSourceProtocol?
     
     /// The `SegnifyProtocol` implementing delegate will configure some properties of the `Segnify` instance.
-    public var delegate: SegnifyProtocol? {
+    public weak var delegate: SegnifyProtocol? {
         didSet {
             if let delegate = delegate {
                 // Apply the segnify configuration.
@@ -111,7 +111,7 @@ open class Segnify: UIView {
     }
     
     /// The `ForwardedEventsProtocol` implementing delegate will be notified if a `Segment` instance has been selected.
-    public var forwardedEventsDelegate: ForwardedEventsProtocol?
+    public weak var forwardedEventsDelegate: ForwardedEventsProtocol?
     
     // MARK: - Segnicator
     

--- a/Segnify/Views/TextSegment.swift
+++ b/Segnify/Views/TextSegment.swift
@@ -21,7 +21,7 @@ open class TextSegment: Segment {
     }
     
     /// Sets the `TextSegmentConfiguration` to configure the segment's appearance.
-    override open var configuration: SegmentProtocol? {
+    override open weak var configuration: SegmentProtocol? {
         didSet {
             if let configuration = configuration as? TextSegmentProtocol {
                 // Apply the text segment configuration.


### PR DESCRIPTION
***Context***
As a developer,
I want to have weak references to any unowned classes, like delegates,
so that we can prevent strong reference cycles.

***Relevant issues***
#14 

***Changes***
- What does it do?
All references to classes and objects, which are not owned by the class which references to them, have been weakened.

- In summary, what changes are made to the code?
References became `weak` where necessary. As a result of that, some `struct` objects became `class` objects.

***Check-list***
- [ ] Acceptance criteria in issue satisfied or Bug fixed
- [ ] Documentation present (relevant information is properly documented)
- [ ] Written tests for test suite (optional for the moment)
- [ ] Tested on devices
- [ ] CHANGELOG updated